### PR TITLE
Add GitHub Actions workflows for WebGL build and deployment

### DIFF
--- a/.github/workflows/delete-pr-folder.yml
+++ b/.github/workflows/delete-pr-folder.yml
@@ -1,0 +1,36 @@
+name: Delete PR Folder on PR Close
+
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  delete-pr-folder:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout gh-pages branch
+        uses: actions/checkout@v4
+        with:
+          ref: gh-pages
+
+      - name: Delete PR folder
+        run: |
+          PR_NUMBER=${{ github.event.pull_request.number }}
+          FOLDER_PATH="pr/$PR_NUMBER"
+          if [ -d "$FOLDER_PATH" ]; then
+            rm -rf $FOLDER_PATH
+            echo "Folder $FOLDER_PATH deleted"
+          else
+            echo "Folder $FOLDER_PATH does not exist"
+          fi
+
+      - name: Commit and push if there are changes
+        run: |
+          git config --global user.name 'github-actions[bot]'
+          git config --global user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git add -A
+          git commit -m "Remove folder for PR ${{ github.event.pull_request.number }}" || exit 0
+          git push

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -67,3 +67,4 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./build/WebGL/WebGL
+          keep_files: true

--- a/.github/workflows/pr-webgl-build.yml
+++ b/.github/workflows/pr-webgl-build.yml
@@ -34,12 +34,6 @@ jobs:
         with:
           unityVersion: '2022.3.17f1'
 
-      - name: Upload Build
-        uses: actions/upload-artifact@v4
-        with:
-          name: Build-WebGL
-          path: build/WebGL
-
       - name: Set enviroments
         run: |
           REPO_NAME=$(echo ${{ github.repository }} | sed -e "s#.*/##")

--- a/.github/workflows/pr-webgl-build.yml
+++ b/.github/workflows/pr-webgl-build.yml
@@ -11,6 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pull-requests: write
 
     steps:
       - name: Checkout

--- a/.github/workflows/pr-webgl-build.yml
+++ b/.github/workflows/pr-webgl-build.yml
@@ -33,6 +33,7 @@ jobs:
           UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
         with:
           unityVersion: '2022.3.17f1'
+          targetPlatform: WebGL
 
       - name: Set enviroments
         run: |

--- a/.github/workflows/pr-webgl-build.yml
+++ b/.github/workflows/pr-webgl-build.yml
@@ -1,0 +1,71 @@
+name: Sample Deploy for GitHub Pages
+
+on:
+  pull_request:
+    branches:
+      - main
+      
+jobs:
+  unity-web-gl-build:
+    name: Build for WebGL
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Cache Library
+        uses: actions/cache@v4
+        with:
+          path: Library
+          key: ${{ runner.os }}-WebGL-library-${{ hashFiles('**/Library/*') }}
+          restore-keys: |
+            ${{ runner.os }}-WebGL-library-
+
+      - name: Build Projects
+        uses: game-ci/unity-builder@v4
+        env:
+          UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
+          UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
+          UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
+        with:
+          unityVersion: '2022.3.17f1'
+
+      - name: Upload Build
+        uses: actions/upload-artifact@v4
+        with:
+          name: Build-WebGL
+          path: build/WebGL
+
+      - name: Set enviroments
+        run: |
+          REPO_NAME=$(echo ${{ github.repository }} | sed -e "s#.*/##")
+          echo "REPO_NAME=$REPO_NAME" >> $GITHUB_ENV
+          DEPLOY_PATH=pr/${{ github.event.pull_request.number }}/${{ github.event.pull_request.head.sha }}
+          echo "DEPLOY_PATH=$DEPLOY_PATH" >> $GITHUB_ENV
+          DEPLOY_URL=https://${{ github.repository_owner }}.github.io/$REPO_NAME/$DEPLOY_PATH
+          echo "DEPLOY_URL=$DEPLOY_URL" >> $GITHUB_ENV
+
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./build/WebGL/WebGL
+          keep_files: true
+          destination_dir: ${{ env.DEPLOY_PATH }}
+
+      - name: Comment PR with Deploy URL
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const issue_number = context.issue.number;
+            const deploy_url = process.env.DEPLOY_URL;
+            github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issue_number,
+              body: `🚀 Deploy preview ready: [${deploy_url}](${deploy_url})`
+            });


### PR DESCRIPTION
This pull request adds two GitHub Actions workflows: one for building and deploying a WebGL project and another for deleting the PR folder when the pull request is closed. The workflows are configured to run on the `main` branch and on pull request events. The `unity-web-gl-build` workflow builds the project using Unity and uploads the build artifacts. The `Sample Deploy for GitHub Pages` workflow deploys the build to GitHub Pages and adds a comment to the pull request with the deploy URL.