### PR TITLE
Add GitHub Actions workflow to add issues/PRs to Kanban project

### DIFF
--- a/.github/workflows/add-to-kanban-project.yml
+++ b/.github/workflows/add-to-kanban-project.yml
@@ -1,0 +1,19 @@
+name: Add to Kanban Project
+
+on:
+  issues:
+    types:
+      - opened
+  pull_request:
+    types:
+      - opened
+
+jobs:
+  add-to-project:
+    name: Add issue/PR to project
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@main
+        with:
+          project-url: https://github.com/orgs/AntiInsufficientSleep/projects/1
+          github-token: ${{ secrets.PROJECT_PERSONAL_ACCESS_TOKEN }}


### PR DESCRIPTION
This pull request adds a GitHub Actions workflow that automatically adds newly opened issues and pull requests to the Kanban project located at https://github.com/orgs/AntiInsufficientSleep/projects/1.