### PR TITLE
Add fetch-depth option to checkout step

### DIFF
--- a/.github/workflows/deploy-pwa.yml
+++ b/.github/workflows/deploy-pwa.yml
@@ -13,6 +13,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Merge PWA
         run: |


### PR DESCRIPTION
This pull request adds the fetch-depth option to the checkout step in order to fetch the complete history of the repository. This is useful for cases where the complete history is required for analysis or debugging purposes.