### PR TITLE
Fix authenticationKeyIssuerID spacing and update IPA file name in iOS workflow

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -88,7 +88,7 @@ jobs:
 
       - name: Upload IPA to App Store Connect
         run: |
-          xcrun altool --upload-app -f 'build/iOS/app.ipa/Cosmic Voyagers.ipa' \
+          xcrun altool --upload-app -f build/iOS/app.ipa/CosmicVoyagers.ipa \
                        -u ${{ secrets.APPLE_ID }} \
                        -p ${{ secrets.APP_SPECIFIC_PASSWORD }} \
                        --type ios

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -84,7 +84,7 @@ jobs:
                      -allowProvisioningUpdates \
                      -authenticationKeyPath `pwd`/private_keys/AuthKey_${{ secrets.APPLE_API_ISSUER_ID }}.p8 \
                      -authenticationKeyID ${{ secrets.APPLE_API_KEY_ID }} \
-                     -authenticationKeyIssuerID  ${{ secrets.APPLE_API_ISSUER_ID }}
+                     -authenticationKeyIssuerID ${{ secrets.APPLE_API_ISSUER_ID }}
 
       - name: Upload IPA to App Store Connect
         run: |


### PR DESCRIPTION
This pull request fixes the spacing issue in the authenticationKeyIssuerID parameter in the iOS workflow and updates the IPA file name to "CosmicVoyagers.ipa".