### PR TITLE
Update webGLTemplate to APPLICATION:Minimal

### DIFF
--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -781,7 +781,7 @@ PlayerSettings:
   webGLDebugSymbols: 0
   webGLEmscriptenArgs: 
   webGLModulesDirectory: 
-  webGLTemplate: APPLICATION:Default
+  webGLTemplate: APPLICATION:Minimal
   webGLAnalyzeBuildSize: 0
   webGLUseEmbeddedResources: 0
   webGLCompressionFormat: 2


### PR DESCRIPTION
This pull request updates the webGLTemplate in the ProjectSettings.asset file to APPLICATION:Minimal. This change ensures that the WebGL build uses the minimal template instead of the default template.