### PR TITLE
Enable Jekyll for GitHub Pages deployment

### DIFF
--- a/.github/workflows/pr-webgl-build.yml
+++ b/.github/workflows/pr-webgl-build.yml
@@ -56,6 +56,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./build/WebGL/WebGL
           keep_files: true
+          enable_jekyll: true
           destination_dir: ${{ env.DEPLOY_PATH }}
           cname: www.cosmic-voyagers.space
 


### PR DESCRIPTION
This pull request enables Jekyll for GitHub Pages deployment. It includes a commit that adds the necessary configuration to enable Jekyll and a git patch that modifies the deployment job to enable Jekyll during the deployment process.