### PR TITLE
Add iOS Simulator workflow for Unity build

### DIFF
--- a/.github/workflows/ios-simulator.yml
+++ b/.github/workflows/ios-simulator.yml
@@ -1,0 +1,53 @@
+name: Unity iOS Simulator Build
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  unity-build:
+    name: Build for iOS Simulator
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Configure Git
+        run: |
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+
+      - name: Merge iOS Simulator
+        run: |
+          git remote add ios-simulator git@github.com:AntiInsufficientSleep/Cosmic-Voyagers-iOS-Simulator.git
+          git fetch ios-simulator
+          git checkout -b ios-simulator ios-simulator/main
+          git merge main
+
+      - name: Cache Library
+        uses: actions/cache@v4
+        with:
+          path: Library
+          key: ${{ runner.os }}-iOS-Simulator-library-${{ hashFiles('**/Packages.lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-iOS-Simulator-library-
+
+      - name: Build Project
+        uses: game-ci/unity-builder@v4
+        env:
+          UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
+          UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
+          UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
+        with:
+          unityVersion: '2022.3.17f1'
+          targetPlatform: iOS
+
+      - name: Upload Build
+        uses: actions/upload-artifact@v4
+        with:
+          name: Build-iOS
+          path: build/iOS


### PR DESCRIPTION
This pull request adds a new workflow for building the Unity project for iOS Simulator. The workflow includes steps for checking out the code, configuring Git, merging the iOS Simulator branch, caching the library, building the project, and uploading the build artifact.