### PR TITLE
Update iOS Simulator remote URL

### DIFF
--- a/.github/workflows/ios-simulator.yml
+++ b/.github/workflows/ios-simulator.yml
@@ -23,7 +23,7 @@ jobs:
 
       - name: Merge iOS Simulator
         run: |
-          git remote add ios-simulator git@github.com:AntiInsufficientSleep/Cosmic-Voyagers-iOS-Simulator.git
+          git remote add ios-simulator https://github.com/AntiInsufficientSleep/Cosmic-Voyagers-iOS-Simulator.git
           git fetch ios-simulator
           git checkout -b ios-simulator ios-simulator/main
           git merge main


### PR DESCRIPTION
This pull request updates the remote URL for the iOS Simulator repository to use HTTPS instead of SSH. This change ensures that the repository can be accessed securely and avoids any potential authentication issues.