### PR TITLE
Remove Android-specific build configurations and add Android workflow for Unity build

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,0 +1,48 @@
+name: Unity Android Build
+
+on:
+  workflow_dispatch
+
+jobs:
+  unity-build:
+    name: Build for Android
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Cache Library
+        uses: actions/cache@v4
+        with:
+          path: Library
+          key: ${{ runner.os }}-Android-library-${{ hashFiles('**/Library/*') }}
+          restore-keys: |
+            ${{ runner.os }}-Android-library-
+
+      - name: Extend Free Disk Space
+        uses: jlumbroso/free-disk-space@main
+
+      - name: Build Projects
+        uses: game-ci/unity-builder@v4
+        env:
+          UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
+          UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
+          UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
+        with:
+          unityVersion: '2022.3.20f1'
+          targetPlatform: Android
+          androidExportType: ${{ 'androidAppBundle' || '' }}
+          androidKeystoreName: ${{ secrets.KEYSTORE_NAME }}
+          androidKeystoreBase64: ${{ secrets.KEYSTORE_FILE }}
+          androidKeystorePass: ${{ secrets.KEYSTORE_PASSWORD }}
+          androidKeyaliasName: ${{  secrets.KEY_ALIAS }}
+          androidKeyaliasPass: ${{  secrets.KEY_PASSWORD }}
+
+      - name: Deploy to Google Play
+        uses: r0adkll/upload-google-play@v1
+        with:
+          serviceAccountJsonPlainText: ${{ secrets.GOOGLE_PLAY_KEY }}
+          packageName: space.cosmicvoyagers
+          releaseFiles: build/Android/Android/Android.abb
+          track: internal

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,12 +48,6 @@ jobs:
         with:
           unityVersion: '2022.3.17f1'
           targetPlatform: ${{ matrix.targetPlatform }}
-          androidExportType: ${{ matrix.targetPlatform == 'Android' && 'androidAppBundle' || '' }}
-          androidKeystoreName: ${{ matrix.targetPlatform == 'Android' && secrets.KEYSTORE_NAME }}
-          androidKeystoreBase64: ${{ matrix.targetPlatform == 'Android' && secrets.KEYSTORE_FILE }}
-          androidKeystorePass: ${{ matrix.targetPlatform == 'Android' && secrets.KEYSTORE_PASSWORD }}
-          androidKeyaliasName: ${{ matrix.targetPlatform == 'Android' && secrets.KEY_ALIAS }}
-          androidKeyaliasPass: ${{ matrix.targetPlatform == 'Android' && secrets.KEY_PASSWORD }}
 
       - name: Upload Build
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
This pull request removes the Android-specific build configurations and adds a new Android workflow for Unity build. The Android-specific build configurations are no longer needed and can be safely removed. The new Android workflow will handle the Unity build process for Android, including caching the library, extending free disk space, building the projects, and deploying to Google Play. This change improves the build process for Android and ensures a smoother workflow.