### PR TITLE
Remove tvOS build option and add tvOS player build option

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,7 +25,6 @@ jobs:
           - PS4 # Build a PS4 standalone.
 #          - PS5 # Build to PlayStation 5 platform.
           - XboxOne # Build an Xbox One standalone.
-          - tvOS # Build a tvOS player.
           - Switch # Build a Nintendo Switch player.
 #          - VisionOS # Build a visionOS player.
 
@@ -90,6 +89,7 @@ jobs:
       matrix:
         targetPlatform:
           - WSAPlayer # Build a Windows Store Apps player.
+          - tvOS # Build a tvOS player.
 
     steps:
       - name: Checkout


### PR DESCRIPTION
This pull request removes the tvOS build option and adds the tvOS player build option. This change ensures that the build process includes the necessary steps for building a tvOS player.