### PR TITLE
Update selected color in StoryScene.unity

### DIFF
--- a/Assets/StoryScene.unity
+++ b/Assets/StoryScene.unity
@@ -6781,7 +6781,7 @@ MonoBehaviour:
     m_NormalColor: {r: 0, g: 0, b: 0, a: 0.8627451}
     m_HighlightedColor: {r: 0, g: 0, b: 0, a: 0.98039216}
     m_PressedColor: {r: 0, g: 0, b: 0, a: 0.65882355}
-    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_SelectedColor: {r: 0, g: 0, b: 0, a: 0.76862746}
     m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
     m_ColorMultiplier: 1
     m_FadeDuration: 0.1


### PR DESCRIPTION
This pull request updates the selected color in the StoryScene.unity file to have an alpha value of 0.76862746 instead of 1.